### PR TITLE
Foreach deterministic

### DIFF
--- a/platform/master/inst/tests/test_3_foreach.R
+++ b/platform/master/inst/tests/test_3_foreach.R
@@ -159,3 +159,12 @@ test_that("Dense darrays: works", {
 
   })
 
+test_that("testing deterministic behavior of foreach", {
+  no_of_executors <- sum(distributedR_status()$Inst)
+  ## loading library in the first foreach to test if it persist in the all 
+  ## the executors
+  foreach(i, 1:no_of_executors, function() { library(RUnit); } )
+ 
+  ## checking if the library was loaded by previous statement in all executors
+  foreach(i, 1:no_of_executors, function() { checkEquals(TRUE, TRUE); } )
+})

--- a/platform/master/inst/tests/test_3_foreach.R
+++ b/platform/master/inst/tests/test_3_foreach.R
@@ -163,8 +163,8 @@ test_that("testing deterministic behavior of foreach", {
   no_of_executors <- sum(distributedR_status()$Inst)
   ## loading library in the first foreach to test if it persist in the all 
   ## the executors
-  foreach(i, 1:no_of_executors, function() { library(RUnit); } )
+  foreach(i, 1:no_of_executors, function() { library(testthat); } )
  
   ## checking if the library was loaded by previous statement in all executors
-  foreach(i, 1:no_of_executors, function() { checkEquals(TRUE, TRUE); } )
+  foreach(i, 1:no_of_executors, function() { expect_that(TRUE, is_true()); } )
 })

--- a/platform/master/src/InMemoryScheduler.cpp
+++ b/platform/master/src/InMemoryScheduler.cpp
@@ -14,7 +14,7 @@
  *copy of the GNU General Public License along with this program; if
  *not, write to the Free Software Foundation, Inc., 59 Temple Place,
  *Suite 330, Boston, MA 02111-1307 USA
- ********************************************************************/ 
+ ********************************************************************/
 
 #include <map>
 #include <sstream>
@@ -43,7 +43,7 @@ using namespace std;
 using namespace boost;
 
 namespace presto {
-    
+
 
 /** A task is done, and the InMemoryScheduler needs to perform further processing
  * @param taskid ID of a task that is completed
@@ -254,26 +254,26 @@ static Worker* best_worker_to_fetch_from(
 
 
 /** Assign a ExecTask to a worker
- * @param tasks 
+ * @param tasks
  * @param inputs
  * @return NULL
  */
 void InMemoryScheduler::AddTask(const std::vector<TaskArg*> &tasks,
-				const int scheduler_policy,
+                                const int scheduler_policy,
                                 const std::vector<int> *inputs) {
 
   std::ostringstream funcstr;
-  funcstr << "*** A new Foreach function received. " << 
+  funcstr << "*** A new Foreach function received. " <<
   tasks.size() << " parallel EXECUTE tasks will be created and sent to Worker : \n" <<
   "function() ";
 
   for (int i = 0; i < tasks[0]->func_str.size(); i++) {
       if (i==tasks[0]->func_str.size()-1)
          funcstr << tasks[0]->func_str[i].c_str();
-      else 
+      else
          funcstr << tasks[0]->func_str[i].c_str() << "\n";
   }
-  
+
   LOG_INFO(funcstr.str());
 #ifdef PROFILING
   fprintf(profiling_output_, "new foreach with %zu tasks\n", tasks.size());
@@ -291,7 +291,7 @@ void InMemoryScheduler::AddTask(const std::vector<TaskArg*> &tasks,
   int task_cnt = 0;
   current_tasks_ += tasks.size();
   map<Worker*, int> schedule_status;
-  
+
   for (int i = 0; i < tasks.size(); i++) {
     task_cnt=i+1;
     // t contains all necessary information to execute a task
@@ -332,7 +332,7 @@ void InMemoryScheduler::AddTask(const std::vector<TaskArg*> &tasks,
       // the given split is a composite array and the task contains split
       // there are multiple tasks, do not consider the composite array location
       // it might be better to distribute task while creating a composite array
-     
+
       //temporarily commented out because we want scheduling decision to take into account composite "list" type operations
      // if (arg.arrays_size() > 1 && num_splits > 0 && tasks.size() > 1) {
       //  continue;
@@ -385,12 +385,12 @@ void InMemoryScheduler::AddTask(const std::vector<TaskArg*> &tasks,
     } else {
       if (num_composite > 0 || num_splits > 0) {  // to check if a task contains splits
         // if the best host does not have enough memory
-        // choose one with the most remaining.        
+        // choose one with the most remaining.
         worker = GetMostMemWorker();
       } else {
         // if this function does not use any splits, we do not have to
         // consider available shared memory size
-        worker = GetRndAvailableWorker();
+        worker = GetNextAvailableWorker();
       }
     }
     }
@@ -434,7 +434,7 @@ void InMemoryScheduler::AddTask(const std::vector<TaskArg*> &tasks,
     taskdata.worker = worker;
 
     // move rest of pieces to best host
-    Response ret; 
+    Response ret;
     for (int32_t i = 0; i < t->args.size(); i++) {
       const Arg &arg = t->args[i];
       //if it's a list, for now treat it as a regular split arg
@@ -452,7 +452,7 @@ void InMemoryScheduler::AddTask(const std::vector<TaskArg*> &tasks,
               if (beingfetched == 0) {  // it is not being fetched
                 Worker *from = best_worker_to_fetch_from(split->workers);
                 // create a fetch task to prepare a task
-                //LOG_DEBUG("Task number %d - Task argument %d - Split %s is not on Worker %15s. It is will be fetched from Worker %15s", 
+                //LOG_DEBUG("Task number %d - Task argument %d - Split %s is not on Worker %15s. It is will be fetched from Worker %15s",
                 //          task_cnt, i+1, split, server_to_string(worker->server).c_str(), server_to_string(from->server).c_str());
                 ::uint64_t fetch_task_id = Fetch(
                     worker,
@@ -492,7 +492,7 @@ void InMemoryScheduler::AddTask(const std::vector<TaskArg*> &tasks,
       } else {  // composite
         string name = CompositeName(arg);
 
-        if (task_cnt==1) 
+        if (task_cnt==1)
             LOG_INFO("Foreach argument '%s' (Internal name: %s) is a Composite array. Composite Array will be created before execution.", arg.name().c_str(), name.c_str());
 
         lock.lock();
@@ -562,7 +562,7 @@ void InMemoryScheduler::AddTask(const std::vector<TaskArg*> &tasks,
                 if (beingfetched == 0) {
                   // if this is not being fetched, fetch it first
                   Worker *from = best_worker_to_fetch_from(split->workers);
-                  
+
                   ::uint64_t fetch_task_id = Fetch(
                       worker,
                       from,
@@ -595,7 +595,7 @@ void InMemoryScheduler::AddTask(const std::vector<TaskArg*> &tasks,
 
             if (cc.num_dependencies == 0) {  // all fetches done
               // create composite
-	      LOG_INFO("Composite Array '%s' - FETCH dependencies resolved. Creating Composite Array.", arg.name().c_str());
+              LOG_INFO("Composite Array '%s' - FETCH dependencies resolved. Creating Composite Array.", arg.name().c_str());
               unique_lock<recursive_mutex> metalock(metadata_mutex);
               ::uint64_t cc_id2 = CreateComposite(cc.worker,
                                                 cc.name,
@@ -635,7 +635,7 @@ void InMemoryScheduler::AddTask(const std::vector<TaskArg*> &tasks,
     // All necessary split is prepared
     if (taskdata.num_dependencies == 0 && taskdata.launched == false) {
       if (task_cnt==1)
-	 LOG_INFO("Foreach arguments has no dependencies. Sending task to Worker for execution");
+         LOG_INFO("Foreach arguments has no dependencies. Sending task to Worker for execution");
       ::uint64_t id = Exec(worker, t);
 #ifdef PROFILING
       fprintf(profiling_output_, "%8.3lf %15s %6zu EDEPS DONE %8.3lf\n",

--- a/platform/master/src/Scheduler.cpp
+++ b/platform/master/src/Scheduler.cpp
@@ -51,7 +51,7 @@ static Scheduler *sch = NULL;
  */
 static void dispatch_task(WorkerInfo *wi, TaskArg *t,
                           ::uint64_t id, ::uint64_t uid) {
-    
+
   NewExecuteRRequest req;
   req.set_id(id);
   req.set_uid(uid);
@@ -81,7 +81,7 @@ static void dispatch_task(WorkerInfo *wi, TaskArg *t,
   // add arguments other than split and composite args
   for (int i = 0; i < t->raw_args.size(); i++)
     req.add_raw_args()->CopyFrom(t->raw_args[i]);
-  
+
   wi->NewExecuteR(req);
   LOG_INFO("EXECUTE TaskID %14d - Sent to Worker %s", static_cast<int>(uid), wi->hostname().c_str());
 }
@@ -176,9 +176,9 @@ void Scheduler::InitiateDataLoader(WorkerInfo* wi,
   req.set_split_size(split_size);
   req.set_split_name(split_prefix);
   req.set_id(000);
-  req.set_uid(taskid);     
-  wi->VerticaLoad(req);     
-  
+  req.set_uid(taskid);
+  wi->VerticaLoad(req);
+
   LOG_INFO("VerticaDL::START TaskID %11d - Sent to Worker %s", taskid, wi->hostname().c_str());
 }
 
@@ -195,16 +195,16 @@ void Scheduler::FetchLoaderStatus(WorkerInfo* wi,
    fetchresultreq[taskid] = wi;
    lock.unlock();
 
-   VerticaDLRequest req; 
+   VerticaDLRequest req;
    req.set_type(VerticaDLRequest::FETCH);
    req.set_id(000);
-   req.set_uid(taskid);     
-   
+   req.set_uid(taskid);
+
    for(int i = 0; i<vnodenames.size(); i++) {
      req.add_query_result(vnodenames[i]);
-   } 
+   }
 
-   wi->VerticaLoad(req);     
+   wi->VerticaLoad(req);
    LOG_INFO("VerticaDL::FETCH TaskID %11d - Sent to Worker %s", static_cast<int>(taskid), wi->hostname().c_str());
 }
 
@@ -219,12 +219,12 @@ void Scheduler::StopDataLoader(WorkerInfo* wi) {
   dataloadereq[taskid]=wi;
   lock.unlock();
 
-  VerticaDLRequest req; 
+  VerticaDLRequest req;
   req.set_type(VerticaDLRequest::STOP);
   req.set_id(000);
-  req.set_uid(taskid);     
-  wi->VerticaLoad(req);     
-  
+  req.set_uid(taskid);
+  wi->VerticaLoad(req);
+
   LOG_INFO("VerticaDL::STOP TaskID %12d - Sent to Worker %s", taskid, wi->hostname().c_str());
 }
 
@@ -253,7 +253,7 @@ std::pair<bool, bool> Scheduler::UpdateTaskResult(TaskDoneRequest* req, bool val
   } else if (!validated)
     foreach_status_->is_error = true;
 
-  taskdones_[taskid] = req; 
+  taskdones_[taskid] = req;
   std::pair<bool, bool> result = std::make_pair((foreach_status_->num_tasks==0), foreach_status_->is_error);
 
   unique_lock<recursive_mutex> lock(metadata_mutex);
@@ -491,7 +491,7 @@ bool Scheduler::Done(TaskDoneRequest* req) {
     LOG_DEBUG("VerticaDL::START TaskID %5d - Received TASKDONE from Worker", static_cast<int>(taskid));
     // Data-Loader started
     std::string hostname = req->location().name();
-    int loader_port = req->loader_port(); 
+    int loader_port = req->loader_port();
     WorkerInfo* workerinfo = dataloadereq[taskid];
 
     presto_master_->GetDataLoader()->HandlePortAssignment(dataloadereq[taskid], loader_port);
@@ -509,10 +509,10 @@ bool Scheduler::Done(TaskDoneRequest* req) {
   if (type == EXEC || type == FETCH || type == LOAD || type == MOVETODRAM ||
       type == CREATECOMPOSITE) {
     double consumed = (double)worker->used / (double)worker->size; // NOLINT
-    
+
     if (consumed > PRESTO_GC_THRESHOLD) {
-      LOG_WARN("Worker %s memory consumption(%1.6f) exceeded PRESTO_GC_THRESHOLD(%1.3f). Removing old versions of Split.", 
-            server_to_string(worker->server).c_str(), consumed, PRESTO_GC_THRESHOLD); 
+      LOG_WARN("Worker %s memory consumption(%1.6f) exceeded PRESTO_GC_THRESHOLD(%1.3f). Removing old versions of Split.",
+            server_to_string(worker->server).c_str(), consumed, PRESTO_GC_THRESHOLD);
       GarbageCollect(worker, GC_DEFAULT_GEN);
     }
   }
@@ -625,7 +625,7 @@ void Scheduler::AddSplit(const string &name, size_t size,
   if (workers.count(w) == 0) {
     ostringstream msg;
     msg << "AddSplit: cannot find a worker to add \"" << w << "\"";
-    throw PrestoWarningException(msg.str());    
+    throw PrestoWarningException(msg.str());
   }
   Worker *worker = workers[w];  // a worker pointer that keeps this split
 
@@ -1011,7 +1011,7 @@ void Scheduler::DeleteSplit(Split *split) {
 
 void Scheduler::AddWorker(
     WorkerInfo *wi, size_t shared_memory,
-    int executors, vector<ArrayStoreData> array_stores) {  
+    int executors, vector<ArrayStoreData> array_stores) {
   string name = wi->hostname()+":"+int_to_string(wi->port());
   if (workers.count(name) != 0) {
     LOG_WARN("Already registered worker (%s) tries to reconnect", name.c_str());
@@ -1210,8 +1210,9 @@ Worker* Scheduler::GetRndAvailableWorker() {
   if (worker_vector.size() == 0) {
     throw PrestoWarningException("GetRndAvailableWorker: no available worker");
   }
-  srand(time(NULL) + getpid());
-  return worker_vector[rand()%worker_vector.size()];
+  current_Worker = (current_Worker+1)%worker_vector.size();
+  //srand(time(NULL) + getpid());
+  return worker_vector[current_Worker];
 }
 
 Scheduler::~Scheduler() {
@@ -1229,7 +1230,7 @@ Scheduler::~Scheduler() {
   for(; fetch_it != fetchtasks.end(); ++fetch_it) {
     delete fetch_it->second;
   }
-  
+
   boost::unordered_map< ::uint64_t, SaveTask*>::iterator save_it = savetasks.begin();
   for(; save_it != savetasks.end(); ++save_it) {
     delete save_it->second;

--- a/platform/master/src/Scheduler.cpp
+++ b/platform/master/src/Scheduler.cpp
@@ -35,7 +35,7 @@ using namespace std;
 using namespace boost;
 
 namespace presto {
-    
+
 extern bool skip_send;
 
 // helper function so we don't have to deal with
@@ -1199,7 +1199,7 @@ Worker* Scheduler::GetMostMemWorker() {
   return worker;
 }
 
-Worker* Scheduler::GetRndAvailableWorker() {
+Worker* Scheduler::GetNextAvailableWorker() {
   boost::unordered_map<std::string, Worker*>::iterator wit;
   vector<Worker*> worker_vector;
   for(wit=workers.begin(); wit != workers.end(); ++wit) {
@@ -1208,10 +1208,9 @@ Worker* Scheduler::GetRndAvailableWorker() {
     }
   }
   if (worker_vector.size() == 0) {
-    throw PrestoWarningException("GetRndAvailableWorker: no available worker");
+    throw PrestoWarningException("GetNextAvailableWorker: no available worker");
   }
   current_Worker = (current_Worker+1)%worker_vector.size();
-  //srand(time(NULL) + getpid());
   return worker_vector[current_Worker];
 }
 

--- a/platform/master/src/Scheduler.h
+++ b/platform/master/src/Scheduler.h
@@ -60,7 +60,7 @@
 #define LOG(n, a...)
 #endif
 
-namespace presto {  
+namespace presto {
 
 class PrestoMaster;
 class ArrayStoreData;
@@ -402,8 +402,8 @@ class Scheduler {
   // completely delete a split (from all workers, arraystores, bookkeeping)
   void DeleteSplit(Split *split);
 
-
-  Worker* GetRndAvailableWorker();
+  // get the next available worker when the foreach has no data partition involved.
+  Worker* GetNextAvailableWorker();
 
   Worker* GetMostMemWorker();
 
@@ -429,6 +429,8 @@ class Scheduler {
   double total_child_scheduler_time_;
 
   // Tracking which worker to execute next task.
+  // This is mainly used when a foreach has no data partition involved and the next
+  // worker is fetched in round-robin fashion.
   int current_Worker;
 
   boost::mutex single_threading_mutex;

--- a/platform/master/src/Scheduler.h
+++ b/platform/master/src/Scheduler.h
@@ -98,7 +98,7 @@ enum TaskType {
   * Arguments to express split information
   * @var TaskArg::raw_args
   * Arguements that are not related to splits
-  * @var TaskArg::sema 
+  * @var TaskArg::sema
   * a semaphore to notify the completion of this task. Upon completion, this is posted
   * @var TaskArg::t
   * a timer to keep track of execution time of this task
@@ -241,6 +241,7 @@ class Scheduler {
 
         total_scheduler_time_ = 0;
         total_child_scheduler_time_ = 0;
+        current_Worker = -1;
   }
 
   virtual ~Scheduler();
@@ -250,7 +251,7 @@ class Scheduler {
   // register new tasks
   void AddTask(TaskArg *t);
   virtual void AddTask(const std::vector<TaskArg*> &tasks,
-		       const int scheduler_policy,
+                       const int scheduler_policy,
                        const std::vector<int> *inputs = NULL) = 0;
 
   // handle a task done notification (task and type describe the task
@@ -309,7 +310,7 @@ class Scheduler {
   }
 
   // -- data loader --
-  
+
   void InitiateDataLoader(WorkerInfo* wi, uint64_t split_size, string split_prefix);
   void FetchLoaderStatus(WorkerInfo* wi, std::vector<std::string>vnodes);
   void StopDataLoader(WorkerInfo* wi);
@@ -322,13 +323,13 @@ class Scheduler {
   void SetForeachError(bool value);
 
   void TaskErrorMsg(const char* error_msg, std::string node = "") {
-    foreach_status_->error_stream.str(std::string()); 
+    foreach_status_->error_stream.str(std::string());
     if(node.empty())
-      foreach_status_->error_stream << " in Master: " << error_msg 
-      <<"\nCheck your code."; 
+      foreach_status_->error_stream << " in Master: " << error_msg
+      <<"\nCheck your code.";
     else
       foreach_status_->error_stream << " in Worker " << node << ": " << error_msg
-      <<"\nCheck your code.";  
+      <<"\nCheck your code.";
   }
 
   void ResetForeach() {
@@ -349,7 +350,7 @@ class Scheduler {
     foreach_status_ = foreach_status;
   }
 
-  // Current implementation is basedon assumption that 
+  // Current implementation is basedon assumption that
   // atmost 1 foreach() will run at time
   ForeachStatus *foreach_status_;
   boost::unordered_map<uint64_t, TaskDoneRequest*> taskdones_;
@@ -401,7 +402,7 @@ class Scheduler {
   // completely delete a split (from all workers, arraystores, bookkeeping)
   void DeleteSplit(Split *split);
 
-  
+
   Worker* GetRndAvailableWorker();
 
   Worker* GetMostMemWorker();
@@ -426,6 +427,9 @@ class Scheduler {
   Timer total_scheduler_timer_;
   double total_scheduler_time_;
   double total_child_scheduler_time_;
+
+  // Tracking which worker to execute next task.
+  int current_Worker;
 
   boost::mutex single_threading_mutex;
 
@@ -467,7 +471,7 @@ class InMemoryScheduler : public Scheduler {
   explicit InMemoryScheduler(const std::string &hostname, PrestoMaster* presto_master);
   ~InMemoryScheduler();
   virtual void AddTask(const std::vector<TaskArg*> &tasks,
-		       const int scheduler_policy = 0,
+                       const int scheduler_policy = 0,
                        const std::vector<int> *inputs = NULL);
   virtual void ChildDone(uint64_t taskid, void *task, TaskType type);
 
@@ -542,7 +546,7 @@ class OOCScheduler : public Scheduler {
  public:
   explicit OOCScheduler(const std::string &hostname, PrestoMaster* presto_master);
   virtual void AddTask(const std::vector<TaskArg*> &tasks,
-		       const int scheduler_policy = 0,
+                       const int scheduler_policy = 0,
                        const std::vector<int> *addtask = NULL);
   virtual void ChildDone(uint64_t taskid, void *task, TaskType type);
   virtual void Flush(Worker *worker, size_t size = 0);


### PR DESCRIPTION
Make foreach execution deterministic when there is no data partition available so that when a user runs a foreach with range equal to the total_number_of_executors, the function will be executed on each executor once. 