### PR TITLE
added logic to fetch cluster_conf file from environment variable

### DIFF
--- a/platform/master/R/master.R
+++ b/platform/master/R/master.R
@@ -218,15 +218,12 @@ distributedR_start <- function(inst=0, mem=0,
     stop("distributedR is already running. Call distributedR_shutdown() to terminate existing session\n")
   }
 
-  if(cluster_conf=="" && Sys.getenv(c("DR_CLUSTER_CONF")) != ""){
-    cluster_conf <- Sys.getenv(c("DR_CLUSTER_CONF"))
-  }
-
   if(presto_home==""){
     presto_home<-ifelse(Sys.getenv(c("DISTRIBUTEDR_HOME"))=="", system.file(package='distributedR'), Sys.getenv(c("DISTRIBUTEDR_HOME")))
   }
+  
   if (cluster_conf==""){
-    cluster_conf <- paste(presto_home,"/conf/cluster_conf.xml",sep="")
+    cluster_conf <- ifelse(Sys.getenv(c("DR_CLUSTER_CONF")) != "", Sys.getenv(c("DR_CLUSTER_CONF")), paste(presto_home,"/conf/cluster_conf.xml",sep=""))
   }
   bin_path <- "./bin/start_proto_worker.sh"
   # Normalize config to expand env vars etc

--- a/platform/master/R/master.R
+++ b/platform/master/R/master.R
@@ -217,6 +217,11 @@ distributedR_start <- function(inst=0, mem=0,
   if (!is.null(pm)){
     stop("distributedR is already running. Call distributedR_shutdown() to terminate existing session\n")
   }
+
+  if(cluster_conf=="" && Sys.getenv(c("DR_CLUSTER_CONF")) != ""){
+    cluster_conf <- Sys.getenv(c("DR_CLUSTER_CONF"))
+  }
+
   if(presto_home==""){
     presto_home<-ifelse(Sys.getenv(c("DISTRIBUTEDR_HOME"))=="", system.file(package='distributedR'), Sys.getenv(c("DISTRIBUTEDR_HOME")))
   }

--- a/platform/master/man/start.Rd
+++ b/platform/master/man/start.Rd
@@ -62,8 +62,7 @@ distributedR_start (inst = 0, mem=0, cluster_conf="", log=2)
         DISTRIBUTEDR_HOME is an environment variable holding path where 
         DistributedR is installed.
 
-     4. Default path where DistributedR is installed. Usually would be something like this:
-        /usr/lib64/R/library/DistributedR or /usr/local/lib64/R/library/DistributedR.} 
+     4. Default path where DistributedR is installed.} 
 
    \item{log}{sets level of information generated in log files. 
     The four severity levels are: 0 (ERROR), 1 (WARNING), 2

--- a/platform/master/man/start.Rd
+++ b/platform/master/man/start.Rd
@@ -48,7 +48,22 @@ distributedR_start (inst = 0, mem=0, cluster_conf="", log=2)
      Currently, memory constraints are not enforced.  
 
      An example configuration file is present in
-     /opt/hp/distributedR/conf/cluster_conf.xml}
+     (/path/to/distributedR)/conf/cluster_conf.xml
+
+     The distributedR_start function can fetch the cluster_conf file in multiple ways with
+     the priority as follows:
+
+     1. cluster_conf parameter specified in the distributedR_start function.
+
+     2. fetch cluster_conf file from DR_CLUSTER_CONF environment variable. This should contain 
+        complete path to the cluster configuration file.
+
+     3. Fetch cluster_conf file from (DISTRIBUTEDR_HOME)/conf/cluster_conf.xml. Here 
+        DISTRIBUTEDR_HOME is an environment variable holding path where 
+        DistributedR is installed.
+
+     4. Default path where DistributedR is installed. Usually would be something like this:
+        /usr/lib64/R/library/DistributedR or /usr/local/lib64/R/library/DistributedR.} 
 
    \item{log}{sets level of information generated in log files. 
     The four severity levels are: 0 (ERROR), 1 (WARNING), 2


### PR DESCRIPTION
DR can now fetch the cluster_conf file from the environment variable DR_CLUSTER_CONF. 

The order of priority would be:

1. cluster_conf passed in the function distributedR_start()
2. Fetch cluster_conf from environment variable DR_CLUSTER_CONF.
3. Look where DR is installed and fetch from that directory. 

@jorgemarsal @fun-indra @shreya2k7 @etduwx Can you guys please review.